### PR TITLE
Update systeminfos.sh

### DIFF
--- a/systeminfos.sh
+++ b/systeminfos.sh
@@ -56,7 +56,7 @@ if [ "$(. /etc/os-release; echo $NAME)" = "Ubuntu" ]; then
 elif [ "$(. /etc/os-release; echo $NAME)" = "openSUSE Leap" ]; then
     zypper in -y curl zip > /dev/null 2>&1
 elif [ "$(. /etc/os-release; echo $NAME)" = "Manjaro Linux" ]; then
-    pacman -Sy curl zip > /dev/null 2>&1
+    pacman -Sy --no-confirm curl zip > /dev/null 2>&1
 else
     printf "Nicht unterstütze Distribution! Überspringe... / Unsupported Distribution! Skip... \n"
 fi


### PR DESCRIPTION
Hi,
added the paman parameter --no-confirm, because otherwise pacman asked for confirmation, hence the script waits for ever. That's quick fix, better would be to check whether curl and zip are already installed.